### PR TITLE
Improve daily view UX

### DIFF
--- a/site/saints/templates/saints/daily.html
+++ b/site/saints/templates/saints/daily.html
@@ -51,6 +51,41 @@
             flex-wrap: wrap;
         }
 
+        .calendar-previews {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            flex: 1;
+        }
+
+        .calendar-preview {
+            background: #f8fafc;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            padding: 8px 12px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+
+        .calendar-preview:hover {
+            background: #e5e7eb;
+        }
+
+        .calendar-preview.active {
+            background: #6b7280;
+            color: white;
+            border-color: #6b7280;
+        }
+
+        .calendar-name {
+            font-weight: 600;
+        }
+
+        .calendar-feasts {
+            font-size: 0.85rem;
+            color: #374151;
+        }
+
         .calendar-select-container .form-label {
             margin-bottom: 0;
             white-space: nowrap;
@@ -371,10 +406,6 @@
                 align-items: stretch;
             }
 
-            .calendar-select-container .form-select {
-                min-width: auto;
-            }
-
             .tabs {
                 flex-direction: column;
             }
@@ -430,14 +461,15 @@
         <!-- Calendar Switcher -->
         <div class="calendar-switcher">
             <div class="calendar-select-container">
-                <label for="calendar-select" class="form-label">Select Calendar Tradition:</label>
-                <select id="calendar-select" class="form-select" onchange="switchCalendar(this.value)">
+                <label class="form-label">Select Calendar Tradition:</label>
+                <div class="calendar-previews">
                     {% for key, label in calendar_options.items %}
-                    <option value="{{ key }}" {% if key == selected_calendar %}selected{% endif %}>
-                        {{ label }}
-                    </option>
+                    <div class="calendar-preview{% if key == selected_calendar %} active{% endif %}" onclick="switchCalendar('{{ key }}')">
+                        <div class="calendar-name">{{ label }}</div>
+                        <div class="calendar-feasts">{{ calendar_peeks|lookup:key|default:"" }}</div>
+                    </div>
                     {% endfor %}
-                </select>
+                </div>
             </div>
         </div>
 
@@ -502,7 +534,7 @@
 
                         <!-- Image Carousel Section -->
                         {% if event_data.biography.images.all %}
-                        <div class="content-section">
+                        <div class="content-section image-section" id="image-section-{{ forloop.counter0 }}">
                             <div class="section-title">Images</div>
                             <div class="image-carousel" id="carousel-{{ forloop.counter0 }}">
                                 <div class="carousel-container">
@@ -578,6 +610,33 @@
                         </div>
                         {% endif %}
 
+                        {% if event_data.biography.feast_description %}
+                        <div class="content-section">
+                            <div class="section-title">About this Feast</div>
+                            <div>
+                                {{ event_data.biography.feast_description.feast_description|linebreaks }}
+                            </div>
+                            {% if event_data.biography.feast_description.citations.all %}
+                            <div class="citations">
+                                <h4>Sources:</h4>
+                                <ul class="citation-list">
+                                    {% for citation in event_data.biography.feast_description.citations.all %}
+                                    <li>
+                                        {% if citation.url %}
+                                        <a href="{{ citation.url }}" target="_blank" rel="noopener noreferrer">
+                                            {{ citation.title|default:citation.citation }}
+                                        </a>
+                                        {% else %}
+                                        {{ citation.title|default:citation.citation }}
+                                        {% endif %}
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+
                         {% if event_data.biography.legend %}
                         <div class="content-section">
                             <div class="section-title">{{ event_data.biography.legend.title }}</div>
@@ -637,33 +696,6 @@
                         {% endfor %}
                         {% endif %}
 
-                        <!-- Feast Description Section -->
-                        {% if event_data.biography.feast_description %}
-                        <div class="content-section">
-                            <div class="section-title">About this Feast</div>
-                            <div>
-                                {{ event_data.biography.feast_description.feast_description|linebreaks }}
-                            </div>
-                            {% if event_data.biography.feast_description.citations.all %}
-                            <div class="citations">
-                                <h4>Sources:</h4>
-                                <ul class="citation-list">
-                                    {% for citation in event_data.biography.feast_description.citations.all %}
-                                    <li>
-                                        {% if citation.url %}
-                                        <a href="{{ citation.url }}" target="_blank" rel="noopener noreferrer">
-                                            {{ citation.title|default:citation.citation }}
-                                        </a>
-                                        {% else %}
-                                        {{ citation.title|default:citation.citation }}
-                                        {% endif %}
-                                    </li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                            {% endif %}
-                        </div>
-                        {% endif %}
 
                         {% if event_data.biography.traditions.all %}
                         <div class="content-section">
@@ -838,10 +870,10 @@
 
         function finishCarouselSetup(carouselId, validImages) {
             if (validImages.length === 0) {
-                // Hide carousel if no valid images
-                const carousel = document.getElementById(`carousel-${carouselId}`);
-                if (carousel) {
-                    carousel.style.display = 'none';
+                // Hide entire image section if no valid images
+                const section = document.getElementById(`image-section-${carouselId}`);
+                if (section) {
+                    section.style.display = 'none';
                 }
                 return;
             }
@@ -920,14 +952,49 @@
         function goToImage(carouselId, index) {
             const carousel = carousels[carouselId];
             if (!carousel) return;
-            
+
             carousel.currentIndex = index;
             renderCarousel(carouselId);
+        }
+
+        function checkSourceLinks() {
+            const citationLinks = document.querySelectorAll('.citation-list a');
+            citationLinks.forEach(link => {
+                fetch(link.href, {method: 'HEAD'}).then(resp => {
+                    if (resp.status >= 400) {
+                        const span = document.createElement('span');
+                        span.textContent = link.textContent;
+                        link.replaceWith(span);
+                    }
+                }).catch(() => {
+                    const span = document.createElement('span');
+                    span.textContent = link.textContent;
+                    link.replaceWith(span);
+                });
+            });
+
+            const readMoreLinks = document.querySelectorAll('.writing-link a');
+            readMoreLinks.forEach(link => {
+                fetch(link.href, {method: 'HEAD'}).then(resp => {
+                    if (resp.status >= 400) {
+                        const parent = link.parentElement;
+                        if (parent) {
+                            parent.textContent = `Source: ${link.href}`;
+                        }
+                    }
+                }).catch(() => {
+                    const parent = link.parentElement;
+                    if (parent) {
+                        parent.textContent = `Source: ${link.href}`;
+                    }
+                });
+            });
         }
 
         // Initialize carousels when page loads
         document.addEventListener('DOMContentLoaded', function() {
             initializeCarousels();
+            checkSourceLinks();
         });
     </script>
 </body>

--- a/site/saints/templates/saints/daily.html
+++ b/site/saints/templates/saints/daily.html
@@ -461,7 +461,6 @@
         <!-- Calendar Switcher -->
         <div class="calendar-switcher">
             <div class="calendar-select-container">
-                <label class="form-label">Select Calendar Tradition:</label>
                 <div class="calendar-previews">
                     {% for key, label in calendar_options.items %}
                     <div class="calendar-preview{% if key == selected_calendar %} active{% endif %}" onclick="switchCalendar('{{ key }}')">

--- a/site/saints/views.py
+++ b/site/saints/views.py
@@ -222,6 +222,20 @@ def daily_view(request, date):
         date=target_date,
         **calendar_filters.get(selected_calendar, calendar_filters['current'])
     ).order_by('order', 'english_name')
+
+    # Gather a short preview of events on each calendar for this date
+    calendar_peeks = {}
+    for key in calendar_options:
+        qs = CalendarEvent.objects.filter(
+            date=target_date, **calendar_filters[key]
+        ).order_by('order', 'english_name')
+        preview_list = []
+        for event in qs:
+            if event.english_rank:
+                preview_list.append(f"{event.english_name} ({event.english_rank})")
+            else:
+                preview_list.append(event.english_name)
+        calendar_peeks[key] = "; ".join(preview_list)
     
     # Try to find biography information for each event
     events_with_biographies = []
@@ -251,6 +265,7 @@ def daily_view(request, date):
         'events_with_biographies': events_with_biographies,
         'selected_calendar': selected_calendar,
         'calendar_options': calendar_options,
+        'calendar_peeks': calendar_peeks,
         'prev_date': prev_date,
         'next_date': next_date,
         'current_liturgical_year': current_liturgical_year,


### PR DESCRIPTION
## Summary
- show previews of each calendar's observances next to the calendar switcher
- hide the entire image section when no valid images load
- move feast description up next to the hagiography
- check links to sources and hide broken ones

## Testing
- `pre-commit run --files site/saints/templates/saints/daily.html site/saints/views.py` *(fails: certificate verify failed while installing node)*

------
https://chatgpt.com/codex/tasks/task_e_685f40ae76dc83218f33bd1a1ef00da8