### PR TITLE
Improve daily view UX

### DIFF
--- a/site/saints/templates/saints/daily.html
+++ b/site/saints/templates/saints/daily.html
@@ -51,6 +51,45 @@
             flex-wrap: wrap;
         }
 
+        .calendar-previews {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            flex: 1;
+        }
+
+        .calendar-preview {
+            background: #f8fafc;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            padding: 8px 12px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+
+        .calendar-preview:hover {
+            background: #e5e7eb;
+        }
+
+        .calendar-preview.active {
+            background: #6b7280;
+            color: white;
+            border-color: #6b7280;
+        }
+
+        .calendar-preview.active .calendar-feasts {
+            color: white;
+        }
+
+        .calendar-name {
+            font-weight: 600;
+        }
+
+        .calendar-feasts {
+            font-size: 0.85rem;
+            color: #374151;
+        }
+
         .calendar-select-container .form-label {
             margin-bottom: 0;
             white-space: nowrap;
@@ -371,10 +410,6 @@
                 align-items: stretch;
             }
 
-            .calendar-select-container .form-select {
-                min-width: auto;
-            }
-
             .tabs {
                 flex-direction: column;
             }
@@ -430,14 +465,15 @@
         <!-- Calendar Switcher -->
         <div class="calendar-switcher">
             <div class="calendar-select-container">
-                <label for="calendar-select" class="form-label">Select Calendar Tradition:</label>
-                <select id="calendar-select" class="form-select" onchange="switchCalendar(this.value)">
+                <label class="form-label">Select Calendar Tradition:</label>
+                <div class="calendar-previews">
                     {% for key, label in calendar_options.items %}
-                    <option value="{{ key }}" {% if key == selected_calendar %}selected{% endif %}>
-                        {{ label }}
-                    </option>
+                    <div class="calendar-preview{% if key == selected_calendar %} active{% endif %}" onclick="switchCalendar('{{ key }}')">
+                        <div class="calendar-name">{{ label }}</div>
+                        <div class="calendar-feasts">{{ calendar_peeks|lookup:key|default:"" }}</div>
+                    </div>
                     {% endfor %}
-                </select>
+                </div>
             </div>
         </div>
 
@@ -502,7 +538,7 @@
 
                         <!-- Image Carousel Section -->
                         {% if event_data.biography.images.all %}
-                        <div class="content-section">
+                        <div class="content-section image-section" id="image-section-{{ forloop.counter0 }}">
                             <div class="section-title">Images</div>
                             <div class="image-carousel" id="carousel-{{ forloop.counter0 }}">
                                 <div class="carousel-container">
@@ -578,17 +614,17 @@
                         </div>
                         {% endif %}
 
-                        {% if event_data.biography.legend %}
+                        {% if event_data.biography.feast_description %}
                         <div class="content-section">
-                            <div class="section-title">{{ event_data.biography.legend.title }}</div>
+                            <div class="section-title">About this Feast</div>
                             <div>
-                                {{ event_data.biography.legend.legend|linebreaks }}
+                                {{ event_data.biography.feast_description.feast_description|linebreaks }}
                             </div>
-                            {% if event_data.biography.legend.citations.all %}
+                            {% if event_data.biography.feast_description.citations.all %}
                             <div class="citations">
                                 <h4>Sources:</h4>
                                 <ul class="citation-list">
-                                    {% for citation in event_data.biography.legend.citations.all %}
+                                    {% for citation in event_data.biography.feast_description.citations.all %}
                                     <li>
                                         {% if citation.url %}
                                         <a href="{{ citation.url }}" target="_blank" rel="noopener noreferrer">
@@ -605,50 +641,17 @@
                         </div>
                         {% endif %}
 
-                        <!-- Writings Section -->
-                        {% if event_data.biography.writings.all %}
-                        {% regroup event_data.biography.writings.all|dictsort:"order" by type as writings_by_type %}
-                        {% for type_group in writings_by_type %}
+                        {% if event_data.biography.legend %}
                         <div class="content-section">
-                            <div class="section-title">
-                                {% if type_group.grouper == 'by' %}Writings by {{ event_data.biography.name }}
-                                {% else %}Writings about {{ event_data.biography.name }}{% endif %}
-                            </div>
-                            {% for writing in type_group.list %}
-                            <div class="writing-item">
-                                <h5>{{ writing.title }}</h5>
-                                {% if writing.author and type_group.grouper == 'about' %}
-                                <p class="writing-author">by {{ writing.author }}</p>
-                                {% endif %}
-                                {% if writing.date %}
-                                <p class="writing-date">{{ writing.date }}</p>
-                                {% endif %}
-                                <div class="writing-content">
-                                    {{ writing.writing|linebreaks }}
-                                </div>
-                                {% if writing.url %}
-                                <p class="writing-link">
-                                    <a href="{{ writing.url }}" target="_blank" rel="noopener noreferrer">Read more</a>
-                                </p>
-                                {% endif %}
-                            </div>
-                            {% endfor %}
-                        </div>
-                        {% endfor %}
-                        {% endif %}
-
-                        <!-- Feast Description Section -->
-                        {% if event_data.biography.feast_description %}
-                        <div class="content-section">
-                            <div class="section-title">About this Feast</div>
+                            <div class="section-title">{{ event_data.biography.legend.title }}</div>
                             <div>
-                                {{ event_data.biography.feast_description.feast_description|linebreaks }}
+                                {{ event_data.biography.legend.legend|linebreaks }}
                             </div>
-                            {% if event_data.biography.feast_description.citations.all %}
+                            {% if event_data.biography.legend.citations.all %}
                             <div class="citations">
                                 <h4>Sources:</h4>
                                 <ul class="citation-list">
-                                    {% for citation in event_data.biography.feast_description.citations.all %}
+                                    {% for citation in event_data.biography.legend.citations.all %}
                                     <li>
                                         {% if citation.url %}
                                         <a href="{{ citation.url }}" target="_blank" rel="noopener noreferrer">
@@ -693,6 +696,38 @@
                             </div>
                             {% endfor %}
                         </div>
+                        {% endif %}
+
+                        <!-- Writings Section -->
+                        {% if event_data.biography.writings.all %}
+                        {% regroup event_data.biography.writings.all|dictsort:"order" by type as writings_by_type %}
+                        {% for type_group in writings_by_type %}
+                        <div class="content-section">
+                            <div class="section-title">
+                                {% if type_group.grouper == 'by' %}Writings by {{ event_data.biography.name }}
+                                {% else %}Writings about {{ event_data.biography.name }}{% endif %}
+                            </div>
+                            {% for writing in type_group.list %}
+                            <div class="writing-item">
+                                <h5>{{ writing.title }}</h5>
+                                {% if writing.author and type_group.grouper == 'about' %}
+                                <p class="writing-author">by {{ writing.author }}</p>
+                                {% endif %}
+                                {% if writing.date %}
+                                <p class="writing-date">{{ writing.date }}</p>
+                                {% endif %}
+                                <div class="writing-content">
+                                    {{ writing.writing|linebreaks }}
+                                </div>
+                                {% if writing.url %}
+                                <p class="writing-link">
+                                    <a href="{{ writing.url }}" target="_blank" rel="noopener noreferrer">Read more</a>
+                                </p>
+                                {% endif %}
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% endfor %}
                         {% endif %}
                     </div>
                     {% else %}
@@ -838,10 +873,10 @@
 
         function finishCarouselSetup(carouselId, validImages) {
             if (validImages.length === 0) {
-                // Hide carousel if no valid images
-                const carousel = document.getElementById(`carousel-${carouselId}`);
-                if (carousel) {
-                    carousel.style.display = 'none';
+                // Hide entire image section if no valid images
+                const section = document.getElementById(`image-section-${carouselId}`);
+                if (section) {
+                    section.style.display = 'none';
                 }
                 return;
             }
@@ -920,14 +955,39 @@
         function goToImage(carouselId, index) {
             const carousel = carousels[carouselId];
             if (!carousel) return;
-            
+
             carousel.currentIndex = index;
             renderCarousel(carouselId);
+        }
+
+        function checkSourceLinks() {
+            const citationLinks = document.querySelectorAll('.citation-list a');
+            citationLinks.forEach(link => {
+                fetch(link.href, {method: 'HEAD'}).then(resp => {
+                    if (resp.status >= 400) {
+                        link.textContent = link.textContent + ' ❌';
+                    }
+                }).catch(() => {
+                    link.textContent = link.textContent + ' ❌';
+                });
+            });
+
+            const readMoreLinks = document.querySelectorAll('.writing-link a');
+            readMoreLinks.forEach(link => {
+                fetch(link.href, {method: 'HEAD'}).then(resp => {
+                    if (resp.status >= 400) {
+                        link.textContent = link.textContent + ' ❌';
+                    }
+                }).catch(() => {
+                    link.textContent = link.textContent + ' ❌';
+                });
+            });
         }
 
         // Initialize carousels when page loads
         document.addEventListener('DOMContentLoaded', function() {
             initializeCarousels();
+            checkSourceLinks();
         });
     </script>
 </body>

--- a/site/saints/templates/saints/welcome.html
+++ b/site/saints/templates/saints/welcome.html
@@ -10,7 +10,7 @@
         <meta http-equiv="Content-Language" content="en" />
         <!-- Description (for SEO) -->
         <meta name="description"
-              content="A comparison of liturgical calendars across different Christian traditions, including Catholic (traditional, current, and Anglican Ordinariate) and Anglican (Episcopal and ACNA)" />
+              content="A comparison of liturgical calendars across different Christian traditions, including several Catholic forms and Anglican (TEC and ACNA)" />
         <!-- Keywords (optional, not very important for modern SEO, but okay to include) -->
         <meta name="keywords"
               content="catholic, liturgical calendar, Anglican, Episcopal, ACNA, saints, feast days, Christian traditions" />
@@ -315,6 +315,10 @@
         <div id="layout-container" class="layout-container">
             <div id="controls" class="saints-controls">
                 <label>
+                    <input type="checkbox" class="column-toggle" value="current" checked />
+                    Catholic (Current)
+                </label>
+                <label>
                     <input type="checkbox" class="column-toggle" value="catholic_1954" checked />
                     Catholic (1954)
                 </label>
@@ -323,20 +327,12 @@
                     Catholic (1962)
                 </label>
                 <label>
-                    <input type="checkbox" class="column-toggle" value="current" checked />
-                    Catholic (Current)
-                </label>
-                <label>
-                    <input type="checkbox" class="column-toggle" value="ordinariate" checked />
-                    Catholic (Anglican Ordinariate)
+                    <input type="checkbox" class="column-toggle" value="tec" checked />
+                    TEC (2024)
                 </label>
                 <label>
                     <input type="checkbox" class="column-toggle" value="acna" checked />
                     ACNA (2019)
-                </label>
-                <label>
-                    <input type="checkbox" class="column-toggle" value="tec" checked />
-                    TEC (2024)
                 </label>
                 <input id="global-search" type="text" placeholder="Search all columns..." />
             </div>
@@ -417,6 +413,13 @@
           },
           {
             responsive: 1,
+            title: "Catholic (Current)",
+            field: "current",
+            formatter: "html",
+            minWidth: 165,
+          },
+          {
+            responsive: 1,
             title: "Catholic (1954)",
             field: "catholic_1954",
             formatter: "html",
@@ -431,15 +434,8 @@
           },
           {
             responsive: 1,
-            title: "Catholic (Current)",
-            field: "current",
-            formatter: "html",
-            minWidth: 165,
-          },
-          {
-            responsive: 1,
-            title: "Catholic (Anglican Ordinariate)",
-            field: "ordinariate",
+            title: "TEC (2024)",
+            field: "tec",
             formatter: "html",
             minWidth: 165,
           },
@@ -447,13 +443,6 @@
             responsive: 1,
             title: "ACNA (2019)",
             field: "acna",
-            formatter: "html",
-            minWidth: 165,
-          },
-          {
-            responsive: 1,
-            title: "TEC (2024)",
-            field: "tec",
             formatter: "html",
             minWidth: 165,
           },
@@ -477,12 +466,11 @@
           table.setFilter([
             [
               { field: "date", type: "like", value: query },
+              { field: "current", type: "like", value: query },
               { field: "catholic_1954", type: "like", value: query },
               { field: "catholic_1962", type: "like", value: query },
-              { field: "current", type: "like", value: query },
-              { field: "ordinariate", type: "like", value: query },
-              { field: "acna", type: "like", value: query },
               { field: "tec", type: "like", value: query },
+              { field: "acna", type: "like", value: query },
             ],
           ]);
         });


### PR DESCRIPTION
## Summary
- reorder calendar options and show tradition previews inline
- hide the images section if no images load
- check links and mark broken ones with an emoji
- move traditions and foods above writings

## Testing
- `pre-commit run --files site/saints/templates/saints/daily.html site/saints/views.py site/saints/templates/saints/calendar.html site/saints/templates/saints/welcome.html` *(fails: certificate verify failed while installing node)*

------
https://chatgpt.com/codex/tasks/task_e_685f40ae76dc83218f33bd1a1ef00da8