### PR TITLE
Add simple chat widget

### DIFF
--- a/site/saints/static/saints/js/chat.js
+++ b/site/saints/static/saints/js/chat.js
@@ -1,0 +1,59 @@
+(function(){
+  const chatToggle=document.createElement('button');
+  chatToggle.id='chat-toggle';
+  chatToggle.textContent='Chat';
+  chatToggle.style.position='fixed';
+  chatToggle.style.bottom='20px';
+  chatToggle.style.right='20px';
+  chatToggle.style.zIndex='1000';
+  document.body.appendChild(chatToggle);
+
+  const chatBox=document.createElement('div');
+  chatBox.id='chat-box';
+  chatBox.style.position='fixed';
+  chatBox.style.bottom='60px';
+  chatBox.style.right='20px';
+  chatBox.style.width='300px';
+  chatBox.style.maxHeight='400px';
+  chatBox.style.background='white';
+  chatBox.style.border='1px solid #ccc';
+  chatBox.style.borderRadius='8px';
+  chatBox.style.display='none';
+  chatBox.style.flexDirection='column';
+  chatBox.style.fontSize='14px';
+  chatBox.innerHTML='<div id="chat-messages" style="flex-grow:1;overflow-y:auto;padding:8px;"></div><form id="chat-form"><input type="text" id="chat-input" style="width:100%;box-sizing:border-box;padding:8px;" autocomplete="off" placeholder="Ask me..."/></form>';
+  document.body.appendChild(chatBox);
+
+  chatToggle.addEventListener('click',()=>{
+    chatBox.style.display=chatBox.style.display==='none'?'flex':'none';
+  });
+
+  document.getElementById('chat-form').addEventListener('submit',async(e)=>{
+    e.preventDefault();
+    const input=document.getElementById('chat-input');
+    const message=input.value.trim();
+    if(!message) return;
+    appendMessage('You',message);
+    input.value='';
+    try{
+      const resp=await fetch('/mcp-chat/',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message})});
+      if(resp.ok){
+        const data=await resp.json();
+        appendMessage('Bot',data.reply);
+      }else{
+        appendMessage('Bot','Error: '+resp.statusText);
+      }
+    }catch(err){
+      appendMessage('Bot','Error sending message');
+    }
+  });
+
+  function appendMessage(sender,text){
+    const msgContainer=document.getElementById('chat-messages');
+    const div=document.createElement('div');
+    div.textContent=sender+': '+text;
+    div.style.marginBottom='4px';
+    msgContainer.appendChild(div);
+    msgContainer.scrollTop=msgContainer.scrollHeight;
+  }
+})();

--- a/site/saints/templates/saints/calendar.html
+++ b/site/saints/templates/saints/calendar.html
@@ -493,5 +493,6 @@
             }
         }
     </script>
+    <script src="{% static 'saints/js/chat.js' %}"></script>
 </body>
 </html>

--- a/site/saints/templates/saints/daily.html
+++ b/site/saints/templates/saints/daily.html
@@ -996,5 +996,6 @@
             checkSourceLinks();
         });
     </script>
+    <script src="{% static 'saints/js/chat.js' %}"></script>
 </body>
 </html>

--- a/site/saints/templates/saints/welcome.html
+++ b/site/saints/templates/saints/welcome.html
@@ -585,5 +585,6 @@
         return adventStart;
       }
         </script>
+        <script src="{% static 'saints/js/chat.js' %}"></script>
     </body>
 </html>

--- a/site/saints/urls.py
+++ b/site/saints/urls.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from saints.api import BiographyViewSet, CalendarListView, DayView, LiturgicalYearView
-from saints.views import calendar_view, comparison_view, daily_view, home_view
+from saints.views import calendar_view, comparison_view, daily_view, home_view, mcp_chat_view
 
 from rest_framework.routers import DefaultRouter
 from rest_framework.views import APIView
@@ -58,6 +58,7 @@ urlpatterns = [
     path("day/<str:date>/", daily_view, name="daily_view"),
     path("calendar/", calendar_view, name="calendar_view"),
     path("calendar/<int:year>/<int:month>/", calendar_view, name="calendar_view_with_date"),
+    path("mcp-chat/", mcp_chat_view, name="mcp_chat"),
 
     # API Endpoints
     path("api/", APIRootView.as_view(), name="api-root"),


### PR DESCRIPTION
## Summary
- add a floating chat widget script
- include widget on comparison, calendar and daily pages
- expose an endpoint to proxy chat requests to OpenAI

## Testing
- `pre-commit run --files site/saints/templates/saints/welcome.html site/saints/templates/saints/daily.html site/saints/templates/saints/calendar.html site/saints/static/saints/js/chat.js site/saints/views.py site/saints/urls.py` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_686704fbf33c832180dfe4e4e4a2d9a3