### PR TITLE
Add django-cron and feedgen dependencies

### DIFF
--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -19,3 +19,5 @@ djangorestframework>=3.14,<4.0
 drf-spectacular>=0.27,<1.0
 django-cors-headers>=4.3,<5.0
 django-debug-toolbar>=4.4,<5.0
+django-cron>=0.6
+feedgen>=0.11


### PR DESCRIPTION
## Summary
- add `django-cron` and `feedgen` to site requirements

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_687da4373224832194e633aab584ff17